### PR TITLE
Add math constants context test

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2406,3 +2406,12 @@ fn test_clear() {
     assert!(context.get_value("five").is_none());
     assert!(eval_with_context("abc(5)", &context).is_err());
 }
+
+#[test]
+fn test_math_constants_context() {
+    let ctx = math_consts_context!();
+    assert_eq!(
+        eval_with_context("math::sin(PI / 2)", &ctx),
+        Ok(Value::Float(1.0))
+    );
+}


### PR DESCRIPTION
## Summary
- add a new integration test verifying math constants via `math_consts_context!`

## Testing
- `cargo test --no-fail-fast` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684a40b74524832ea36175eff10c466e